### PR TITLE
Smc monitor

### DIFF
--- a/src/main/java/bayonet/math/NumericalUtils.java
+++ b/src/main/java/bayonet/math/NumericalUtils.java
@@ -56,7 +56,7 @@ public class NumericalUtils
    * @param y A number (in log scale)
    * @return logAdded value
    */
-  public static double logDifference(double x, double y) {
+  public static double logAbsDifference(double x, double y) {
     // make x the max
     if (y > x) {
       double temp = x;

--- a/src/main/java/bayonet/math/NumericalUtils.java
+++ b/src/main/java/bayonet/math/NumericalUtils.java
@@ -48,6 +48,27 @@ public class NumericalUtils
   }
   
   /**
+   * Equivalent, but more numerically resilient to underflows:
+   *
+   * Math.log(|Math.exp(x) - Math.exp(y)|);
+   *
+   * @param x A number (in log scale)
+   * @param y A number (in log scale)
+   * @return logAdded value
+   */
+  public static double logDifference(double x, double y) {
+    // make x the max
+    if (y > x) {
+      double temp = x;
+      x = y;
+      y = temp;
+    }
+    // now x is bigger
+    double negDiff = y - x;
+    return x + java.lang.Math.log(1.0 - java.lang.Math.exp(negDiff));
+  }
+
+  /**
    * Equivalent, but more numerically resilient to underflows and faster than:
    * 
    * Math.log(Math.exp(x) + Math.exp(y));

--- a/src/main/java/bayonet/smc/ParticlePopulation.java
+++ b/src/main/java/bayonet/smc/ParticlePopulation.java
@@ -79,6 +79,17 @@ public final class ParticlePopulation<P> implements Serializable
     this.logScaling = logScaling;
   }
 
+  public double [] getLogWeights()
+  {
+    double [] result = normalizedWeights.clone();
+    int i = 0;
+    for (double normalizedWeight : result) {
+      result[i] = Math.log(normalizedWeight) + logScaling;
+      i++;
+    }
+    return result;
+  }
+
   public double getNormalizedWeight(final int index)
   {
     if (equallyWeighted())

--- a/src/main/java/bayonet/smc/ParticlePopulation.java
+++ b/src/main/java/bayonet/smc/ParticlePopulation.java
@@ -9,6 +9,7 @@ import java.util.stream.DoubleStream;
 
 import bayonet.distributions.ExhaustiveDebugRandom;
 import bayonet.distributions.Multinomial;
+import bayonet.smc.ResamplingScheme.ResampledContext;
 
 
 
@@ -17,6 +18,7 @@ public final class ParticlePopulation<P> implements Serializable
   private static final long serialVersionUID = 1L;
   
   public final List<P> particles;
+  public final List<Integer> ancestors;
   private final double [] normalizedWeights;
   
   /**
@@ -48,26 +50,30 @@ public final class ParticlePopulation<P> implements Serializable
   public static <P> ParticlePopulation<P> buildDestructivelyFromLogWeights(
       double [] logWeights, 
       final List<P> particles, 
+      final List<Integer> ancestors,
       final double logScaling)
   {
     if (logWeights.length != particles.size())
       throw new RuntimeException("Dimensionality of weights should match the dim of particles");
     double logWeightsScaling = Multinomial.expNormalize(logWeights);
-    return new ParticlePopulation<>(particles, logWeights, logScaling + logWeightsScaling);
+    return new ParticlePopulation<>(particles, ancestors, logWeights, logScaling + logWeightsScaling);
   }
   
   public static <P> ParticlePopulation<P> buildEquallyWeighted(
       final List<P> particles, 
+      final List<Integer> ancestors,
       final double logScaling)
   {
-    return new ParticlePopulation<>(particles, null, logScaling);
+    return new ParticlePopulation<>(particles, ancestors, null, logScaling);
   }
   
   private ParticlePopulation(
       final List<P> particles, 
+      final List<Integer> ancestors,
       final double[] normalizedWeights,
       final double logScaling)
   {
+    this.ancestors = ancestors;
     this.particles = particles;
     this.normalizedWeights = normalizedWeights;
     this.logScaling = logScaling;
@@ -115,14 +121,20 @@ public final class ParticlePopulation<P> implements Serializable
       for (int i = 0; i < nParticles(); i++)
         prs[i] = getNormalizedWeight(i);
       List<P> resampled = new ArrayList<>();
-      for (int i = 0; i < nParticles(); i++)
-        resampled.add(particles.get(debugRandom.nextCategorical(prs)));
-      return ParticlePopulation.buildEquallyWeighted(resampled, logScaling); 
+      List<Integer> ancestors = new ArrayList<>();
+      for (int i = 0; i < nParticles(); i++) {
+        int particleIdx = debugRandom.nextCategorical(prs);
+        ancestors.add(particleIdx);
+        resampled.add(particles.get(particleIdx));
+      }
+      return ParticlePopulation.buildEquallyWeighted(resampled, ancestors, logScaling);
     }
     else
     {
-      final List<P> resampled = resamplingScheme.resample(random, normalizedWeights, particles);
-      return ParticlePopulation.buildEquallyWeighted(resampled, logScaling);
+      ResampledContext<P> resampledContext = resamplingScheme.resample(random, normalizedWeights, particles);
+      final List<P> resampled = resampledContext.particles;
+      final List<Integer> ancestors = resampledContext.ancestors;
+      return ParticlePopulation.buildEquallyWeighted(resampled, ancestors, logScaling);
     }
   }
 

--- a/src/main/java/bayonet/smc/ResamplingScheme.java
+++ b/src/main/java/bayonet/smc/ResamplingScheme.java
@@ -57,8 +57,12 @@ public enum ResamplingScheme
    * @return The location of the n darts, sorted in ascending order.
    */
   public abstract double[] getSortedCumulativeProbabilities(Random rand, int nDarts);
-  
-  public <T> List<T> resample(
+  public class ResampledContext<T> {
+    List<T> particles;
+    List<Integer> ancestors;
+  }
+
+  public <T> ResampledContext<T> resample(
       final Random rand, 
       final double [] w, 
       final List<T> particles)
@@ -66,7 +70,7 @@ public enum ResamplingScheme
     return resample(rand, w, particles, particles.size());
   }
   
-  public <T> List<T> resample(
+  public <T> ResampledContext<T> resample(
       final Random rand, 
       final double [] w, 
       final List<T> particles, 
@@ -74,6 +78,7 @@ public enum ResamplingScheme
   {
     final double [] darts = getSortedCumulativeProbabilities(rand, nSamples); 
     final List<T> result = new ArrayList<>(nSamples);
+    final List<Integer> ancestors = new ArrayList<Integer>(nSamples);
     double sum = 0.0;
     int nxtDartIdx = 0;
     for (int i = 0; i < w.length; i++)
@@ -87,6 +92,7 @@ public enum ResamplingScheme
         if (darts[dartIdx] < right)
         {
           result.add(particles.get(i)); //result.incrementCount(i, 1.0);
+          ancestors.add(i);
           nxtDartIdx++;
         }
         else 
@@ -98,6 +104,9 @@ public enum ResamplingScheme
     NumericalUtils.checkIsClose(1.0, sum);
     if (result.size() != nSamples)
       throw new RuntimeException();
-    return result;
+    ResampledContext<T> resampledContext = new ResampledContext<T>();
+    resampledContext.particles = result;
+    resampledContext.ancestors = ancestors;
+    return resampledContext;
   }
 }


### PR DESCRIPTION
## What?
1. Add `logAbsDifference` method to `NumericalUtils.java`, i.e., log(|x-y|).
2. Add class `ResampledContext`. It is used as the return type of resampling procedures. `ResampledContext` a context containing `List<T>` (particles) and `List<Integer> ancestors`.

## Why?
1. Useful utility.
2. Useful for returning metadata induced by resampling procedures, which can be used for, for example, visualizing SMC genealogies.
